### PR TITLE
[codex] Refactor JDBC tests to use JdbcTemplate instead of DataSource fields

### DIFF
--- a/lab/26-jdbc/src/test/java/rewards/internal/account/JdbcAccountRepositoryTests.java
+++ b/lab/26-jdbc/src/test/java/rewards/internal/account/JdbcAccountRepositoryTests.java
@@ -4,10 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -25,17 +21,15 @@ import common.money.Percentage;
  */
 public class JdbcAccountRepositoryTests {
 
-	private JdbcAccountRepository repository;
+    private JdbcAccountRepository repository;
 
-	private DataSource dataSource;
-	
-	private JdbcTemplate jdbcTemplate;
+    private JdbcTemplate jdbcTemplate;
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		dataSource = createTestDataSource();
-		jdbcTemplate = new JdbcTemplate(dataSource);
-		repository = new JdbcAccountRepository(jdbcTemplate);
+        DataSource dataSource = createTestDataSource();
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        repository = new JdbcAccountRepository(jdbcTemplate);
 	}
 
 	@Test
@@ -67,31 +61,20 @@ public class JdbcAccountRepositoryTests {
 	}
 
 	@Test
-	public void testUpdateBeneficiaries() throws SQLException {
+    public void testUpdateBeneficiaries() {
 		Account account = repository.findByCreditCard("1234123412341234");
 		account.makeContribution(MonetaryAmount.valueOf("8.00"));
 		repository.updateBeneficiaries(account);
 		verifyBeneficiaryTableUpdated();
 	}
 
-	private void verifyBeneficiaryTableUpdated() throws SQLException {
-		String sql = "select SAVINGS from T_ACCOUNT_BENEFICIARY where NAME = ? and ACCOUNT_ID = ?";
-		PreparedStatement stmt = dataSource.getConnection().prepareStatement(sql);
-
-		// assert Annabelle has $4.00 savings now
-		stmt.setString(1, "Annabelle");
-		stmt.setLong(2, 0L);
-		ResultSet rs = stmt.executeQuery();
-		rs.next();
-		assertEquals(MonetaryAmount.valueOf("4.00"), MonetaryAmount.valueOf(rs.getString(1)));
-
-		// assert Corgan has $4.00 savings now
-		stmt.setString(1, "Corgan");
-		stmt.setLong(2, 0L);
-		rs = stmt.executeQuery();
-		rs.next();
-		assertEquals(MonetaryAmount.valueOf("4.00"), MonetaryAmount.valueOf(rs.getString(1)));
-	}
+        private void verifyBeneficiaryTableUpdated() {
+                String sql = "select SAVINGS from T_ACCOUNT_BENEFICIARY where NAME = ? and ACCOUNT_ID = ?";
+                assertEquals(MonetaryAmount.valueOf("4.00"), MonetaryAmount
+                                .valueOf(jdbcTemplate.queryForObject(sql, String.class, "Annabelle", 0L)));
+                assertEquals(MonetaryAmount.valueOf("4.00"), MonetaryAmount
+                                .valueOf(jdbcTemplate.queryForObject(sql, String.class, "Corgan", 0L)));
+        }
 
 	private DataSource createTestDataSource() {
 		return new EmbeddedDatabaseBuilder()

--- a/lab/26-jdbc/src/test/java/rewards/internal/reward/JdbcRewardRepositoryTests.java
+++ b/lab/26-jdbc/src/test/java/rewards/internal/reward/JdbcRewardRepositoryTests.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.math.BigDecimal;
-import java.sql.SQLException;
 import java.util.Map;
 
 import javax.sql.DataSource;
@@ -35,21 +34,19 @@ import rewards.internal.account.Account;
  */
 public class JdbcRewardRepositoryTests {
 
-	private JdbcRewardRepository repository;
+        private JdbcRewardRepository repository;
 
-	private DataSource dataSource;
-
-	private JdbcTemplate jdbcTemplate;
+        private JdbcTemplate jdbcTemplate;
 
 	@BeforeEach
 	public void setUp() throws Exception {
-		dataSource = createTestDataSource();
-		jdbcTemplate = new JdbcTemplate(dataSource);
-		repository = new JdbcRewardRepository(jdbcTemplate);
+                DataSource dataSource = createTestDataSource();
+                jdbcTemplate = new JdbcTemplate(dataSource);
+                repository = new JdbcRewardRepository(jdbcTemplate);
 	}
 
-	@Test
-	public void testCreateReward() throws SQLException {
+        @Test
+        public void testCreateReward() {
 		Dining dining = Dining.createDining("100.00", "1234123412341234", "0123456789");
 
 		Account account = new Account("1", "Keith and Keri Donald");
@@ -65,7 +62,7 @@ public class JdbcRewardRepositoryTests {
 		verifyRewardInserted(confirmation, dining);
 	}
 
-	private void verifyRewardInserted(RewardConfirmation confirmation, Dining dining) throws SQLException {
+        private void verifyRewardInserted(RewardConfirmation confirmation, Dining dining) {
 		assertEquals(1, getRewardCount());
 
 		//	dTODO-02: Use JdbcTemplate to query for a map of all column values
@@ -92,7 +89,7 @@ public class JdbcRewardRepositoryTests {
 		assertEquals(SimpleDate.today().asDate(), values.get("DINING_DATE"));
 	}
 
-	private int getRewardCount() throws SQLException {
+        private int getRewardCount() {
 		// dTODO-01: Use JdbcTemplate to query for the number of rows in the T_REWARD table
 		// - Use "SELECT count(*) FROM T_REWARD" as SQL statement
 		final Integer count = jdbcTemplate.queryForObject("SELECT count(*) FROM T_REWARD", Integer.class);


### PR DESCRIPTION
## Summary
- Replace `DataSource` fields in account and reward repository tests with local `JdbcTemplate` usage
- Verify database changes using `JdbcTemplate` queries instead of manual JDBC

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*
- `bash ../gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68b19047e36c832ba9f81c321b7cd2b7